### PR TITLE
feat(analytics): track risk_checker_submitted event in GA4

### DIFF
--- a/app/parent-email-risk-checker/parent-email-risk-checker-client.tsx
+++ b/app/parent-email-risk-checker/parent-email-risk-checker-client.tsx
@@ -19,6 +19,7 @@ import {
   track,
   trackCtaClick,
   trackFreeToolPageView,
+  trackRiskCheckerSubmitted,
   trackShareClicked,
   trackToolCompleted,
   trackToolStarted,
@@ -137,6 +138,35 @@ function buildIssueWarnings(issues: ParentEmailRiskIssue[], copy: CheckerCopy) {
   const uniqueWarnings = [...new Set(warnings)];
 
   return uniqueWarnings.slice(0, 4);
+}
+
+function isParentEmailRiskResult(
+  payload: unknown,
+): payload is ParentEmailRiskResult {
+  const candidate = payload as Partial<ParentEmailRiskResult> | null;
+
+  if (
+    typeof candidate !== "object" ||
+    candidate === null ||
+    typeof candidate.riskScore !== "number" ||
+    typeof candidate.saferVersion !== "string" ||
+    !["low", "medium", "high"].includes(candidate.riskLevel ?? "") ||
+    !Array.isArray(candidate.issuesDetected)
+  ) {
+    return false;
+  }
+
+  return candidate.issuesDetected.every((issue) => {
+    return (
+      typeof issue === "object" &&
+      issue !== null &&
+      typeof issue.id === "string" &&
+      typeof issue.label === "string" &&
+      typeof issue.category === "string" &&
+      (issue.matchedPhrase === undefined ||
+        typeof issue.matchedPhrase === "string")
+    );
+  });
 }
 
 export default function ParentEmailRiskCheckerClient({
@@ -299,12 +329,13 @@ export default function ParentEmailRiskCheckerClient({
         | ParentEmailRiskResult
         | { error?: string };
 
-      if (!response.ok || !("riskScore" in payload)) {
+      if (!response.ok || !isParentEmailRiskResult(payload)) {
         setResult(null);
         setError((payload as { error?: string }).error || copy.processingError);
         return;
       }
 
+      trackRiskCheckerSubmitted(locale);
       setResult(payload);
     } catch {
       setResult(null);

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -95,6 +95,22 @@ export const track = (event: string, props?: Record<string, any>) =>
 export const trackEvent = (event: string, props?: Record<string, any>) =>
   baseTrack(event, props);
 
+export const trackRiskCheckerSubmitted = (locale: "en" | "de") => {
+  if (typeof window === "undefined" || typeof window.gtag !== "function") {
+    return;
+  }
+
+  window.gtag("event", "risk_checker_submitted", {
+    event_category: "engagement",
+    event_label: "parent_email_risk_checker",
+    locale,
+    page_path:
+      locale === "de"
+        ? "/de/parent-email-risk-checker"
+        : "/parent-email-risk-checker",
+  });
+};
+
 export const trackCtaClick = ({
   ctaText,
   ctaLocation,


### PR DESCRIPTION
- Add trackRiskCheckerSubmitted() in lib/analytics.ts

- Fire 'risk_checker_submitted' event on successful API response

- Pass locale parameter (en/de) for downstream filtering

- Reuses existing GA4 config (G-GFCNQYCHFK) and Consent Mode v2 gating

- No new dependencies, no GTM, no Google Ads tag